### PR TITLE
投稿機能の実装

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { CreatePostModalContainer } from '@/features/posts/containers/CreatePostModalContainer';
 import { useState } from 'react';
 import { Footer } from './Footer';
 import { Header } from './Header';
-import { CreatePostModalContainer } from '@/features/posts/containers/CreatePostModalContainer';
 
 interface MainLayoutProps {
   children: React.ReactNode;

--- a/src/features/posts/actions/submitPostsAction.ts
+++ b/src/features/posts/actions/submitPostsAction.ts
@@ -1,38 +1,40 @@
 'use server';
 
-import { createPost } from "../services/posts/createPost";
+import { createPost } from '../services/posts/createPost';
 
-type StateType = {
-  status: 'success' | 'error';
-  message: string;
-} | undefined
+type StateType =
+  | {
+      status: 'success' | 'error';
+      message: string;
+    }
+  | undefined;
 
 export type SubmitPostsActionType = (
-    prevState: StateType,
-    formData: FormData
-  ) => Promise<StateType>;
-
-export const submitPostsAction = async(
   prevState: StateType,
-  queryData: FormData
- ): Promise<StateType> => {
+  formData: FormData,
+) => Promise<StateType>;
+
+export const submitPostsAction = async (
+  prevState: StateType,
+  queryData: FormData,
+): Promise<StateType> => {
   const handleName = queryData.get('handleName') as string;
   const content = queryData.get('content') as string;
 
   if (!handleName || !content) {
     return {
       status: 'error',
-      message: 'error'
-    }
+      message: 'error',
+    };
   }
 
   await createPost({
     handleName,
-    content
-  })
+    content,
+  });
 
   return {
     status: 'success',
-    message: 'success!!'
-  }
-}
+    message: 'success!!',
+  };
+};

--- a/src/features/posts/containers/CreatePostModalContainer.tsx
+++ b/src/features/posts/containers/CreatePostModalContainer.tsx
@@ -1,17 +1,26 @@
-'use client'
+'use client';
 
-import { useActionState, useState } from "react"
-import { submitPostsAction } from "../actions/submitPostsAction"
-import { CreatePostModal, type CreatePostModalProps } from "../presentational/CreatePostModal"
+import { useRef } from 'react';
+import { usePostSubmission } from '../hooks/usePostSubmission';
+import {
+  CreatePostModal,
+  type CreatePostModalProps,
+} from '../presentational/CreatePostModal';
 
+export interface CreatePostModalContainerProps
+  extends Omit<CreatePostModalProps, 'formAction' | 'onReset'> {}
 
-export const CreatePostModalContainer = (props: CreatePostModalProps) => {
-  const [state, formAction] = useActionState(submitPostsAction, undefined)
+export const CreatePostModalContainer = (
+  props: CreatePostModalContainerProps,
+) => {
+  const modalRef = useRef<{ resetForm: () => void }>(null);
 
-  return (
-    <CreatePostModal
-      {...props}
-      formAction={formAction}
-    />
-  )
-}
+  const handleSuccess = () => {
+    modalRef.current?.resetForm();
+    props.onClose();
+  };
+
+  const { formAction } = usePostSubmission(handleSuccess);
+
+  return <CreatePostModal {...props} ref={modalRef} formAction={formAction} />;
+};

--- a/src/features/posts/hooks/usePostSubmission.ts
+++ b/src/features/posts/hooks/usePostSubmission.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useActionState, useEffect, useState } from 'react';
+import { submitPostsAction } from '../actions/submitPostsAction';
+
+type StateType =
+  | {
+      status: 'success' | 'error';
+      message: string;
+    }
+  | undefined;
+
+export const usePostSubmission = (onSuccess: () => void) => {
+  const [state, formAction] = useActionState(submitPostsAction, undefined);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  useEffect(() => {
+    if (state?.status === 'success' && isProcessing) {
+      onSuccess();
+      setIsProcessing(false);
+    }
+  }, [state, isProcessing, onSuccess]);
+
+  const wrappedFormAction = (formData: FormData) => {
+    setIsProcessing(true);
+    formAction(formData);
+  };
+
+  return {
+    state,
+    formAction: wrappedFormAction,
+    isProcessing,
+  };
+};

--- a/src/features/posts/presentational/CreatePostModal.tsx
+++ b/src/features/posts/presentational/CreatePostModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/shadcn/dialog';
 import { Input } from '@/components/ui/shadcn/input';
 import { Textarea } from '@/components/ui/shadcn/textarea';
-import { useState } from 'react';
+import { forwardRef, useImperativeHandle, useState } from 'react';
 
 export interface CreatePostModalProps {
   open: boolean;
@@ -18,15 +18,31 @@ export interface CreatePostModalProps {
   formAction?: (payload: FormData) => void;
 }
 
-export function CreatePostModal({ open, onClose, formAction }: CreatePostModalProps) {
+export interface CreatePostModalRef {
+  resetForm: () => void;
+}
+
+export const CreatePostModal = forwardRef<
+  CreatePostModalRef,
+  CreatePostModalProps
+>(function CreatePostModal({ open, onClose, formAction }, ref) {
   const [handleName, setHandleName] = useState('');
   const [content, setContent] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const resetForm = () => {
+    setHandleName('');
+    setContent('');
+    setIsSubmitting(false);
+  };
+
+  useImperativeHandle(ref, () => ({
+    resetForm,
+  }));
+
   const handleClose = () => {
     if (!isSubmitting) {
-      setHandleName('');
-      setContent('');
+      resetForm();
       onClose();
     }
   };
@@ -38,7 +54,13 @@ export function CreatePostModal({ open, onClose, formAction }: CreatePostModalPr
           <DialogTitle>新しい投稿を作成</DialogTitle>
         </DialogHeader>
 
-        <form className="space-y-4" action={formAction}>
+        <form
+          className="space-y-4"
+          action={(formData) => {
+            setIsSubmitting(true);
+            formAction?.(formData);
+          }}
+        >
           <div>
             <label
               htmlFor="handleName"
@@ -53,7 +75,7 @@ export function CreatePostModal({ open, onClose, formAction }: CreatePostModalPr
               placeholder="あなたの名前"
               maxLength={50}
               disabled={isSubmitting}
-              name='handleName'
+              name="handleName"
               required
             />
           </div>
@@ -73,7 +95,7 @@ export function CreatePostModal({ open, onClose, formAction }: CreatePostModalPr
               rows={4}
               maxLength={280}
               disabled={isSubmitting}
-              name='content'
+              name="content"
               required
             />
             <div className="text-right text-sm text-gray-500 mt-1">
@@ -102,4 +124,4 @@ export function CreatePostModal({ open, onClose, formAction }: CreatePostModalPr
       </DialogContent>
     </Dialog>
   );
-}
+});

--- a/src/features/posts/services/posts/createPost.ts
+++ b/src/features/posts/services/posts/createPost.ts
@@ -1,30 +1,29 @@
-import { getClient } from "@/db/getClient";
-import { posts } from "@/db/schema/posts";
+import { getClient } from '@/db/getClient';
+import { posts } from '@/db/schema/posts';
 
 type Arguments = {
-    handleName: string;
-    content: string;
-}
+  handleName: string;
+  content: string;
+};
 
-export const createPost = async({
-  handleName,
-  content
-}: Arguments) => {
+export const createPost = async ({ handleName, content }: Arguments) => {
   const client = getClient();
 
   try {
-    const inserted = await client.insert(posts).values({
-      handleName,
-      content
-    }).returning({ id: posts.id });
+    const inserted = await client
+      .insert(posts)
+      .values({
+        handleName,
+        content,
+      })
+      .returning({ id: posts.id });
 
-     // IDを取得
+    // IDを取得
     const id = inserted[0].id;
 
     // IDを返す
     return id;
-
-  } catch(e) {
-    console.log(e)
+  } catch (e) {
+    console.log(e);
   }
-}
+};


### PR DESCRIPTION
## Summary
• 投稿成功後にモーダルが自動で閉じるように改善
• フォームのリセット機能を追加
• カスタムフック`usePostSubmission`を新規作成して状態管理を改善

## Test plan
- [ ] 投稿モーダルを開く
- [ ] ハンドルネームと投稿内容を入力して投稿
- [ ] 投稿成功後にモーダルが自動で閉じることを確認
- [ ] 再度モーダルを開いてフォームがリセットされていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)